### PR TITLE
Build fails with TypeScript 1.8. Pin the typescript version down to 1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/angular/angular-electron#readme",
   "devDependencies": {
     "electron-prebuilt": "^0.36.7",
-    "typescript": "^1.7.5",
+    "typescript": "~1.7.5",
     "rimraf": "^2.5.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
TypeScript 1.8 fails with 

```
node_modules/angular2/src/facade/promise.d.ts(1,10): error TS2661: Cannot re-export name that is not defined in the module.
```

Pinning TypeScript down to 1.7 is a quick fix to make the project build & run
